### PR TITLE
🎨 Palette: Add "Skip to main content" link and improve focus indicators

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -338,6 +338,28 @@ footer p {
     margin: 0;
 }
 
+/* Accessibility */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: #2a77de;
+    color: white !important;
+    padding: 8px;
+    z-index: 2000;
+    transition: top 0.3s;
+    text-decoration: none;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
+*:focus-visible {
+    outline: 3px solid #2a77de;
+    outline-offset: 2px;
+}
+
 /* Utility Classes */
 .text-center {
     text-align: center;

--- a/frontend/src/components/layout/Layout.js
+++ b/frontend/src/components/layout/Layout.js
@@ -6,8 +6,9 @@ import '../../App.css'; // For .container styles or other global layout styles
 const Layout = ({ children }) => {
   return (
     <>
+      <a href="#main-content" className="skip-link">Skip to main content</a>
       <Navbar />
-      <main>
+      <main id="main-content">
         {/* The container class here provides centered, max-width content area */}
         {/* Individual pages can choose to use it or have full-width sections */}
         {children}


### PR DESCRIPTION
Implemented a "Skip to main content" link and enhanced visual focus indicators to improve the accessibility and keyboard navigation experience of the AICADO company website. The skip link is visually hidden until it receives focus, providing a clean UI for mouse users while supporting accessibility. Global focus-visible styles ensure that keyboard users have clear, high-contrast indicators of their current focus position.

---
*PR created automatically by Jules for task [4015158806223570693](https://jules.google.com/task/4015158806223570693) started by @laxman-panthi*