### PR TITLE
🎨 Palette: Improve keyboard accessibility with high-visibility focus styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-16 - Form Feedback UX
 **Learning:** Users often feel uncertain when a form submission has no visible state change. Providing an immediate "submitting" state and an accessible success message significantly improves perceived reliability.
 **Action:** Always implement a submission status state for forms, including a disabled state for the submit button and a ARIA-live region for status updates.
+
+## 2025-05-15 - High-Visibility Keyboard Focus
+**Learning:** Default browser focus rings often lack sufficient contrast or clash with custom component designs (like buttons with rounded corners). Using `:focus-visible` allows for high-contrast, tailored focus indicators that only appear for keyboard users, maintaining visual polish for mouse users.
+**Action:** Implement global `:focus-visible` styles and specific overrides for interactive components (buttons, inputs) using `box-shadow` or `outline-offset` to ensure the focus ring respects `border-radius`.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -10,6 +10,17 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
+/* Better focus styles for keyboard users */
+:focus-visible {
+    outline: 3px solid #2a77de;
+    outline-offset: 2px;
+}
+
+/* Hide focus ring for mouse users if focus-visible is supported */
+:focus:not(:focus-visible) {
+    outline: none;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
@@ -152,6 +163,11 @@ a:hover {
 .cta-button:hover {
     background: #215dab; /* Darker AICADO Blue */
     text-decoration: none;
+}
+
+.cta-button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px #f4f7f6, 0 0 0 5px #2a77de;
 }
 
 .cta-button:disabled {
@@ -320,6 +336,13 @@ a:hover {
     border: 1px solid #ccc;
     border-radius: 5px;
     box-sizing: border-box;
+}
+
+.form-group input:focus-visible,
+.form-group textarea:focus-visible {
+    outline: none;
+    border-color: #2a77de;
+    box-shadow: 0 0 0 4px rgba(42, 119, 222, 0.2);
 }
 .form-group textarea {
     resize: vertical;


### PR DESCRIPTION
Implemented `:focus-visible` styles to improve accessibility for keyboard users. This change provides high-contrast visual indicators for focused interactive elements (links, buttons, inputs) while suppressing focus rings for mouse users, ensuring a delightful and accessible experience. Verified via Playwright screenshots and keyboard navigation simulation.

---
*PR created automatically by Jules for task [7613906913323934169](https://jules.google.com/task/7613906913323934169) started by @laxman-panthi*