### PR TITLE
🎨 Palette: Improve keyboard accessibility with skip link and focus styles

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -359,3 +359,44 @@ footer p {
 .service-item .clear-float { /* Utility to clear float if needed */
     clear: both;
 }
+
+/* Accessibility - Skip Link */
+.skip-link {
+    position: absolute;
+    top: -100px;
+    left: 0;
+    background: #2a77de;
+    color: white !important;
+    padding: 8px 16px;
+    z-index: 2000;
+    transition: top 0.2s ease;
+    text-decoration: none;
+    font-weight: bold;
+    border-radius: 0 0 5px 0;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
+/* Global Focus Styles */
+/* Using :focus-visible to only show focus ring for keyboard users */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[tabindex]:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(42, 119, 222, 0.6);
+}
+
+/* Specific override for elements with solid background to ensure contrast */
+.cta-button:focus-visible {
+    box-shadow: 0 0 0 2px white, 0 0 0 5px rgba(42, 119, 222, 0.6);
+}
+
+/* Target main content focus from skip link */
+#main-content:focus {
+    outline: none;
+}

--- a/frontend/src/components/layout/Layout.js
+++ b/frontend/src/components/layout/Layout.js
@@ -6,8 +6,9 @@ import '../../App.css'; // For .container styles or other global layout styles
 const Layout = ({ children }) => {
   return (
     <>
+      <a href="#main-content" className="skip-link">Skip to Content</a>
       <Navbar />
-      <main>
+      <main id="main-content" tabIndex="-1">
         {/* The container class here provides centered, max-width content area */}
         {/* Individual pages can choose to use it or have full-width sections */}
         {children}


### PR DESCRIPTION
### 🎨 Palette: Accessibility Improvements

#### 💡 What:
I have added two key accessibility features to the AICADO website:
1.  **Skip to Content Link**: A visually hidden link that appears on focus, allowing keyboard users to bypass navigation and jump straight to the main content.
2.  **Enhanced Focus Indicators**: Global `:focus-visible` styles that provide a clear, high-contrast focus ring (using `box-shadow`) for interactive elements like buttons, links, and form inputs.

#### 🎯 Why:
These changes significantly improve the user experience for people navigating the site with a keyboard or screen reader. The skip link saves time by skipping repetitive navigation, and the enhanced focus indicators provide clear visual feedback on the current focus position.

#### ♿ Accessibility Improvements:
- Improved keyboard operability (WCAG 2.1.1).
- Added a "Bypass Blocks" mechanism (WCAG 2.4.1).
- Enhanced focus visibility (WCAG 2.4.7).

#### ✅ Verification:
- Verified visually using Playwright (screenshots captured of focused skip link, buttons, and inputs).
- Confirmed that the skip link correctly moves focus to the `#main-content` area.
- Verified that focus indicators are only visible during keyboard navigation using `:focus-visible`.
- Successfully ran `pnpm build` in the frontend.

---
*PR created automatically by Jules for task [5096138851932257557](https://jules.google.com/task/5096138851932257557) started by @laxman-panthi*