### PR TITLE
🎨 Palette: Improve keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-16 - Form Feedback UX
 **Learning:** Users often feel uncertain when a form submission has no visible state change. Providing an immediate "submitting" state and an accessible success message significantly improves perceived reliability.
 **Action:** Always implement a submission status state for forms, including a disabled state for the submit button and a ARIA-live region for status updates.
+
+## 2025-05-14 - Keyboard Navigation Visibility
+**Learning:** Global focus states were inconsistent or missing, hindering keyboard navigation. Using :focus-visible with a high-contrast outline and subtle box-shadow ensures accessibility without affecting mouse users' experience.
+**Action:** Apply a consistent :focus-visible style in App.css using AICADO's primary blue (#2a77de) and ensure a 'Skip to Content' link is present in the root Layout.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -343,6 +343,32 @@ footer p {
     text-align: center;
 }
 
+/* Accessibility */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    background: #2a77de;
+    color: white;
+    padding: 8px;
+    z-index: 2000;
+    transition: top 0.3s;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
+:focus-visible {
+    outline: 3px solid #2a77de;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(42, 119, 222, 0.4);
+}
+
+main:focus {
+    outline: none;
+}
+
 
 /* Service Item Icon Styling */
 .service-item-icon {

--- a/frontend/src/components/layout/Layout.js
+++ b/frontend/src/components/layout/Layout.js
@@ -6,8 +6,9 @@ import '../../App.css'; // For .container styles or other global layout styles
 const Layout = ({ children }) => {
   return (
     <>
+      <a href="#main-content" className="skip-link">Skip to Content</a>
       <Navbar />
-      <main>
+      <main id="main-content" tabIndex="-1">
         {/* The container class here provides centered, max-width content area */}
         {/* Individual pages can choose to use it or have full-width sections */}
         {children}


### PR DESCRIPTION
This PR enhances the accessibility of the AICADO company website by improving keyboard navigation. 

### 💡 What: 
1. Added a "Skip to Content" link that is visually hidden until focused, allowing keyboard users to bypass the navigation header.
2. Implemented consistent, high-visibility `:focus-visible` styles across the application using the brand's primary blue color.

### 🎯 Why: 
Keyboard users currently have to tab through all navigation links on every page load to reach the main content. Furthermore, the default focus indicators were subtle or missing on certain elements, making navigation difficult for users with motor or visual impairments.

### ♿ Accessibility:
- Added a skip link targeting the main content area.
- Ensured interactive elements have a clear 3px blue outline and subtle box-shadow when focused via keyboard.
- Verified with Playwright that focus indicators are correctly applied and the skip link functions as intended.

---
*PR created automatically by Jules for task [13558157387693357572](https://jules.google.com/task/13558157387693357572) started by @laxman-panthi*