### PR TITLE
🎨 Palette: Enhance Contact Form UX and Navbar Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-14 - Keyboard Navigation Visibility
 **Learning:** Global focus states were inconsistent or missing, hindering keyboard navigation. Using :focus-visible with a high-contrast outline and subtle box-shadow ensures accessibility without affecting mouse users' experience.
 **Action:** Apply a consistent :focus-visible style in App.css using AICADO's primary blue (#2a77de) and ensure a 'Skip to Content' link is present in the root Layout.
+
+## 2024-03-27 - Form Accessibility & Feedback Patterns
+**Learning:** Combining visible required indicators (*), ARIA attributes (aria-required), and helpful placeholders significantly reduces cognitive load. Providing a specific "Sending..." state with a spinner reinforces that an action is in progress.
+**Action:** Use the .required-asterisk, .spinner, and .success-message (alert box) classes in App.css for consistent form UX.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -161,9 +161,33 @@ a:hover {
 }
 
 .success-message {
-    color: #28a745; /* Success Green */
+    background: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+    padding: 0.75rem 1.25rem;
     margin-top: 1rem;
-    font-weight: bold;
+    border-radius: 4px;
+}
+
+.spinner {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50%;
+    border-top-color: #fff;
+    animation: spin 0.6s linear infinite;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.required-asterisk {
+    color: #d93025;
+    margin-left: 2px;
 }
 
 /* Home Page Specific Styles */

--- a/frontend/src/components/layout/Navbar.js
+++ b/frontend/src/components/layout/Navbar.js
@@ -5,7 +5,7 @@ const Navbar = () => {
   return (
     <header>
       <nav className='container'>
-        <Link to='/' className='logo-link'>
+        <Link to='/' className='logo-link' aria-label='AICADO - Home'>
           AICADO
         </Link>
         <ul>

--- a/frontend/src/pages/ContactPage.js
+++ b/frontend/src/pages/ContactPage.js
@@ -33,20 +33,20 @@ const ContactPage = () => {
           <h2>Send Us a Message</h2>
           <form onSubmit={handleSubmit}>
             <div className='form-group'>
-              <label htmlFor='name'>Full Name:</label>
-              <input type='text' id='name' name='name' value={formData.name} onChange={handleChange} required />
+              <label htmlFor='name'>Full Name: <span className='required-asterisk' aria-hidden='true'>*</span></label>
+              <input type='text' id='name' name='name' value={formData.name} onChange={handleChange} required aria-required='true' placeholder='Jane Doe' />
             </div>
             <div className='form-group'>
-              <label htmlFor='email'>Email Address:</label>
-              <input type='email' id='email' name='email' value={formData.email} onChange={handleChange} required />
+              <label htmlFor='email'>Email Address: <span className='required-asterisk' aria-hidden='true'>*</span></label>
+              <input type='email' id='email' name='email' value={formData.email} onChange={handleChange} required aria-required='true' placeholder='jane.doe@example.com' />
             </div>
             <div className='form-group'>
-              <label htmlFor='subject'>Subject:</label>
-              <input type='text' id='subject' name='subject' value={formData.subject} onChange={handleChange} required />
+              <label htmlFor='subject'>Subject: <span className='required-asterisk' aria-hidden='true'>*</span></label>
+              <input type='text' id='subject' name='subject' value={formData.subject} onChange={handleChange} required aria-required='true' placeholder='How can we help you?' />
             </div>
             <div className='form-group'>
-              <label htmlFor='message'>Message:</label>
-              <textarea id='message' name='message' rows='6' value={formData.message} onChange={handleChange} required></textarea>
+              <label htmlFor='message'>Message: <span className='required-asterisk' aria-hidden='true'>*</span></label>
+              <textarea id='message' name='message' rows='6' value={formData.message} onChange={handleChange} required aria-required='true' placeholder='Tell us about your project...'></textarea>
             </div>
             <button
               type='submit'
@@ -54,7 +54,12 @@ const ContactPage = () => {
               disabled={status === 'submitting'}
               aria-live='polite'
             >
-              {status === 'submitting' ? 'Sending...' : 'Send Message'}
+              {status === 'submitting' ? (
+                <>
+                  <span className='spinner' aria-hidden='true'></span>
+                  Sending...
+                </>
+              ) : 'Send Message'}
             </button>
             {status === 'success' && (
               <p className='success-message' role='status'>


### PR DESCRIPTION
💡 What:
- Added `aria-label="AICADO - Home"` to the logo link in the Navbar for better screen reader context.
- Re-styled `.success-message` as a professional alert box (green background/border).
- Added a `.spinner` CSS animation for asynchronous feedback.
- Enhanced the Contact form with:
    - Visible red asterisks for required fields (with `aria-hidden="true"`).
    - `aria-required="true"` and descriptive placeholders for all inputs.
    - An inline spinner and "Sending..." text in the submit button during submission.

🎯 Why:
- These micro-UX touches make the AICADO brand more accessible and the contact process more intuitive.
- The loading state prevents double-submissions and provides immediate feedback.

♿ Accessibility:
- Brand logo is now explicitly labeled for screen readers.
- Form validation requirements are communicated both visually and semantically.
- State transitions (Sending -> Success) are announced via ARIA live regions.

---
*PR created automatically by Jules for task [6973588252059305753](https://jules.google.com/task/6973588252059305753) started by @laxman-panthi*