### PR TITLE
🎨 Palette: Add character counter to contact form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-15 - Visual Cues for Required Fields
 **Learning:** Adding a visible red asterisk alongside `aria-required` provides a clearer experience for all users, not just those using screen readers. Placing the asterisk before the colon in labels maintains a professional look while ensuring the indicator is clearly associated with the field name.
 **Action:** Use the `.required-asterisk` class with a `<span>*</span>` inside labels, placed before any colons, and pair it with `aria-required="true"` on the input.
+
+## 2025-05-16 - Character Counter for Limited Inputs
+**Learning:** For forms with strict character limits, providing a real-time counter associated via `aria-describedby` and `aria-live="polite"` improves accessibility and user confidence. Using inline styles for these small enhancements helps maintain a lean CSS architecture when a utility-first framework is absent.
+**Action:** Implement real-time character counters for any input field with a `maxLength`. Ensure they are correctly associated with the input for screen readers and styled consistently with the form's aesthetic.

--- a/frontend/src/pages/ContactPage.js
+++ b/frontend/src/pages/ContactPage.js
@@ -46,7 +46,24 @@ const ContactPage = () => {
             </div>
             <div className='form-group'>
               <label htmlFor='message'>Message<span className='required-asterisk' aria-hidden='true'>*</span>:</label>
-              <textarea id='message' name='message' rows='6' value={formData.message} onChange={handleChange} required aria-required='true'></textarea>
+              <textarea
+                id='message'
+                name='message'
+                rows='6'
+                value={formData.message}
+                onChange={handleChange}
+                required
+                aria-required='true'
+                maxLength='1000'
+                aria-describedby='message-counter'
+              ></textarea>
+              <div
+                id='message-counter'
+                style={{ fontSize: '0.85rem', color: '#666', textAlign: 'right', marginTop: '0.25rem', display: 'block' }}
+                aria-live='polite'
+              >
+                {formData.message.length} / 1000 characters
+              </div>
             </div>
             <button
               type='submit'


### PR DESCRIPTION
💡 What: Added a real-time character counter and a 1000-character limit to the Message field on the Contact Page.
🎯 Why: Improves user experience by providing clear feedback on input constraints and prevents potential submission errors due to length limits.
♿ Accessibility: Associated the counter with the textarea using `aria-describedby` and used `aria-live="polite"` for real-time updates for screen reader users.

---
*PR created automatically by Jules for task [3345466861192725629](https://jules.google.com/task/3345466861192725629) started by @laxman-panthi*